### PR TITLE
Fix name of neurips 2024

### DIFF
--- a/src/data/publication.ts
+++ b/src/data/publication.ts
@@ -33,7 +33,7 @@ export const publicationData: Publication[] = [
   },
   {
     year: "2024",
-    conference: "NeurIPS 2024 Workshop: <a href='https://sites.google.com/view/neurips2024-ftw/home'>Fine-Tuning in Modern Machine Learning: Principles and Scalability (FITML)</a>",
+    conference: "NeurIPS 2024 Workshop: Fine-Tuning in Modern Machine Learning: Principles and Scalability (FITML)",
     title: "Mastering Task Arithmetic: τJp as a Key Indicator for Weight Disentanglement",
     authors: "Kotaro Yoshida, Yuji Naraki, Takafumi Horie, Ryosuke Yamaki, Ryotaro Shimizu, Yuki Saito, Julian McAuley, Hiroki Naganuma",
     paperUrl: "https://openreview.net/forum?id=uvTDEA2z5f",


### PR DESCRIPTION
This pull request includes a minor change to the `publicationData` array in the `src/data/publication.ts` file. The change involves updating the conference name for a specific publication entry by removing the HTML anchor tag, since it did not work correctly.

* [`src/data/publication.ts`](diffhunk://#diff-c78b16463a8589d7124624b3f90cf8241d5a7ed41d41a9bec40ba12cba007a5aL36-R36): Removed the HTML anchor tag from the `conference` field of the NeurIPS 2024 Workshop entry.