### PR TITLE
LREC conference name standardization

### DIFF
--- a/src/data/publication.ts
+++ b/src/data/publication.ts
@@ -40,7 +40,7 @@ export const publicationData: Publication[] = [
   },
   {
     year: "2026",
-    conference: "The 2026 International Conference on Language Resources and Evaluation (LREC2026)",
+    conference: "The 2026 International Conference on Language Resources and Evaluation (LREC)",
     title: "LegalRikai: Open Benchmark -- Benchmark for Complex Japanese Corporate Legal Tasks",
     authors: "Shogo Fujita, Yuji Naraki, Yiqing Zhu, Shinsuke Mori",
     paperUrl: "https://arxiv.org/abs/2512.11297",

--- a/src/data/publication.ts
+++ b/src/data/publication.ts
@@ -68,7 +68,7 @@ export const publicationData: Publication[] = [
   },
   {
     year: "2022",
-    conference: "The 2022 International Conference on Language Resources and Evaluation (LREC2022)",
+    conference: "The 2022 International Conference on Language Resources and Evaluation (LREC)",
     title: "Evaluating the Effects of Embedding with Speaker Identity Information in Dialogue Summarization",
     authors: "Yuji NARAKI, Tetsuya SAKAI, Yoshihiko HAYASHI",
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Update the conference name for the 2026 LREC publication to use '(LREC)' instead of '(LREC2026)' as requested.

---
[Slack Thread](https://jarvis0326.slack.com/archives/D0AH8NAKRS4/p1772940556006799?thread_ts=1772940556.006799&cid=D0AH8NAKRS4)

<p><a href="https://cursor.com/agents/bc-70252c5d-750e-51a0-813d-449912ea2509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70252c5d-750e-51a0-813d-449912ea2509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->