### PR TITLE
Add article entries to portfolio

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,8 @@ import { ExperienceEntry } from "@/components/experience-entry";
 import { experienceData } from "@/data/experience";
 import { PortfolioEntry } from "@/components/portfolio-entry";
 import { portfolioData } from "@/data/portfolio";
+import { ArticleEntry } from "@/components/article-entry";
+import { articleData } from "@/data/articles";
 import { sectionOrder, Section } from "@/data/section-order";
 import { grantData } from "@/data/grant";
 import { GrantEntry } from "@/components/grant-entry";
@@ -182,6 +184,21 @@ export default function Home() {
                         <div className="space-y-12">
                           {portfolioData.map((portfolio, index) => (
                             <PortfolioEntry key={index} portfolio={portfolio} />
+                          ))}
+                        </div>
+                      </section>
+                    )
+                  );
+                case Section.Articles:
+                  return (
+                    articleData.length > 0 && (
+                      <section key={sectionName}>
+                        <h2 className="font-serif text-md mb-12 tracking-wide uppercase">
+                          Articles
+                        </h2>
+                        <div className="space-y-12">
+                          {articleData.map((article, index) => (
+                            <ArticleEntry key={index} article={article} />
                           ))}
                         </div>
                       </section>

--- a/src/components/article-entry.tsx
+++ b/src/components/article-entry.tsx
@@ -1,0 +1,52 @@
+import { ArrowUpRight } from "lucide-react";
+import { Article } from "@/data/articles";
+
+export function ArticleEntry({ article }: { article: Article }) {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col flex-1">
+        <h3 className="font-serif text-md mb-3">
+          <a
+            href={article.url}
+            className="group inline-flex items-center gap-2 hover:text-zinc-600 transition-colors duration-300"
+          >
+            {article.title}
+            <ArrowUpRight
+              size={16}
+              className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform duration-300"
+            />
+          </a>
+        </h3>
+
+        {article.tags && (
+          <div className="flex gap-2 mb-4 flex-wrap">
+            {article.tags.map((tag, index) => (
+              <span
+                key={index}
+                className="text-xs text-zinc-600 px-2 py-1 bg-zinc-100 rounded-full"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className="flex gap-6">
+          <a
+            href={article.url}
+            className="group inline-flex items-center gap-2 text-xs text-zinc-500 hover:text-zinc-900 transition-colors duration-300"
+          >
+            <ArrowUpRight
+              size={12}
+              className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform duration-300"
+            />
+            <span className="tracking-wider uppercase">Article</span>
+          </a>
+        </div>
+        <p className="text-sm text-zinc-600 mb-4 mt-4 italic">
+          {article.description}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/data/articles.ts
+++ b/src/data/articles.ts
@@ -1,0 +1,23 @@
+export interface Article {
+  title: string;
+  description: string;
+  tags?: string[];
+  url: string;
+}
+
+export const articleData: Article[] = [
+  {
+    title: "プレイブックに基づく契約書レビューにおけるLLMの性能検証",
+    description:
+      "A technical article evaluating LLM performance on playbook-based Japanese contract review, including prompt-language and input-order comparisons across frontier models.",
+    tags: ["Legal NLP", "LLM Evaluation", "Prompt Engineering"],
+    url: "https://tech.legalforce.co.jp/entry/playbook_contractreview_llm",
+  },
+  {
+    title: "ICLR 2026 参加報告：現地参加の感想と研究紹介",
+    description:
+      "A conference report from ICLR 2026 covering an onsite poster presentation and research trends in model editing, fine-grained VLM perception, and AI agent evaluation.",
+    tags: ["ICLR 2026", "VLM", "Model Merging", "AI Agents"],
+    url: "https://tech.cierpa.co.jp/entry/2026/06/08/130658",
+  },
+];

--- a/src/data/section-order.ts
+++ b/src/data/section-order.ts
@@ -1,6 +1,7 @@
 export enum Section {
   Education = "education",
   Experience = "experience",
+  Articles = "articles",
   Portfolio = "portfolio",
   Publication = "publication",
   Preprint = "preprint",
@@ -17,5 +18,6 @@ export const sectionOrder = [
   Section.Experience,
   Section.Education,
   Section.Grant,
+  Section.Articles,
   // Section.Portfolio,
 ];


### PR DESCRIPTION
## Summary
- Add article entries in a new `src/data/articles.ts` data file
- Add a dedicated `ArticleEntry` component for article rendering
- Register a new ARTICLES section in the section order
- Keep `src/data/portfolio.ts` unchanged from `main`

## Verification
- npm run build